### PR TITLE
bugfix: callbacks should not be async methods, tests don't emit 'task…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/) and this project adheres to [Semantic Versioning](http://semver.org/).
 
+---
+
 ## Unreleased
 
-- Unreleased changes here
+### Changed
+
+- callback methods should not be async
+- quieter tests (no more info warnings)
+
+---
 
 ## 0.0.2
 
@@ -14,6 +21,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/) and this p
 
 - fixed bug in producer where send was putting too many arguments into it's done callback
 - changed README to be more representative of how to use AIOKinesisProducer
+
+---
 
 ## 0.0.1
 

--- a/aiokinesis/producer.py
+++ b/aiokinesis/producer.py
@@ -41,7 +41,7 @@ class AIOKinesisProducer:
             PartitionKey=partition_key
         )
 
-    async def _complete_produce_request(self, task):
+    def _complete_produce_request(self, task):
         self._outstanding_tasks.remove(task)
 
     async def _sender_routine(self):

--- a/tests/test_producer.py
+++ b/tests/test_producer.py
@@ -64,6 +64,7 @@ async def test_producer_add_message(stream_name, partition_key, value):
             partition_key,
             json.dumps(value),
         )
+        await producer.stop()
 
 
 @pytest.mark.asyncio
@@ -101,6 +102,7 @@ async def test_producer_send_message(stream_name, partition_key, value):
             Data=json.dumps(value),
             PartitionKey=partition_key
         )
+        await producer.stop()
 
 
 @pytest.mark.asyncio
@@ -121,3 +123,4 @@ async def test_producer_send_message_done_callback(mocker):
     await asyncio.sleep(0.1)
 
     producer._complete_produce_request.assert_called_once()
+    await producer.stop()


### PR DESCRIPTION
… pending but was destroyed' messages anymore